### PR TITLE
fprintf crash fixed

### DIFF
--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -60,14 +60,14 @@ CompileTimeError Parser::_predefined_error(const String& p_what, const String& p
 		Vect2i(), p_dbg_info);
 }
 
-void Parser::parse(const String& p_source, const String& p_file_path) {
+void Parser::parse(ptr<Tokenizer> p_tokenizer) {
 	
-	tokenizer = newptr<Tokenizer>();
+	tokenizer = p_tokenizer;
 	file_node = new_node<FileNode>();
-	file_node->source = p_source;
-	file_node->path = Path(p_file_path).absolute();
 
-	tokenizer->tokenize(file_node->source, file_node->path);
+	// TODO: maybe redundant
+	file_node->source = tokenizer->get_source();
+	file_node->path = tokenizer->get_source_path();
 
 	while (true) {
 	

--- a/core/platform/_windows.cpp
+++ b/core/platform/_windows.cpp
@@ -94,9 +94,9 @@ void _Platform::console_log(const char* p_message, bool p_stderr, Console::Color
 	if (p_background == Console::Color::DEFAULT) p_background = Console::Color::BLACK;
 	_set_console_color(p_forground, p_background);
 	if (p_stderr) {
-		fprintf(stderr, p_message);
+		fprintf(stderr, "%s", p_message);
 	} else {
-		fprintf(stdout, p_message);
+		fprintf(stdout, "%s", p_message);
 	}
 	_set_console_color(Console::Color::L_WHITE);
 }

--- a/include/compiler/compiler.h
+++ b/include/compiler/compiler.h
@@ -57,7 +57,8 @@ public:
 	void add_flag(CompileFlags p_flag);
 	void add_include_dir(const String& p_dir);
 	ptr<Bytecode> compile(const String& p_path);
-	ptr<Bytecode> compile_source(const String& p_source, const String& p_path = "<string-soruce>");
+	ptr<Bytecode> compile_file(const String& p_path);
+	//ptr<Bytecode> compile_source(const String& p_source, const String& p_path = "<string-soruce>");
 
 
 };

--- a/include/compiler/parser.h
+++ b/include/compiler/parser.h
@@ -524,7 +524,8 @@ public:
 	*/
 
 	// Methods.
-	void parse(const String& p_source, const String& p_file_path);
+	//void parse(const String& p_source, const String& p_file_path);
+	void parse(ptr<Tokenizer> p_tokenizer);
 #ifdef DEBUG_BUILD
 	void print_tree() const;
 #endif

--- a/include/compiler/tokenizer.h
+++ b/include/compiler/tokenizer.h
@@ -27,6 +27,8 @@
 #define TOKENIZER_H
 
 #include "core/core.h"
+#include "native/file.h"
+
 #include "builtin_functions.h"
 #include "builtin_types.h"
 
@@ -157,12 +159,17 @@ private: // members.
 
 public:
 	// methods.
+	void tokenize(ptr<File> p_file);
 	void tokenize(const String& p_source, const String& p_source_path = "<PATH-NOT-SET>");
+
 	const TokenData& next(int p_offset = 0);
 	const TokenData& peek(int p_offset = 0, bool p_safe = false) const;
 	Vect2i get_pos() const;
 	uint32_t get_width() const;
 	const TokenData& get_token_at(const Vect2i& p_pos, bool p_safe = false) const;
+
+	const String& get_source() const;
+	const String& get_source_path() const;
 
 	static const char* get_token_name(Token p_tk);
 
@@ -173,6 +180,8 @@ private:
 	void _eat_eof();
 	void _eat_const_value(const var& p_value, int p_eat_size = 0);
 	void _eat_identifier(const String& p_idf, int p_eat_size = 0);
+
+	void _clear();
 
 };
 

--- a/include/native/file.h
+++ b/include/native/file.h
@@ -73,7 +73,6 @@ public:
 	String get_path() const { return path; }
 	int get_mode() const { return mode; }
 
-
 	String read_text();
 	String read_line();
 	void write_text(const String& p_text);
@@ -83,6 +82,8 @@ public:
 
 	var read();
 	void write(const var& p_what);
+
+	var __iter_begin() override;
 
 
 protected:

--- a/include/native/iterators.h
+++ b/include/native/iterators.h
@@ -132,6 +132,7 @@ public:
 };
 
 
+
 }
 
 #endif // _RUNTIME_TYPES_H

--- a/native/file.cpp
+++ b/native/file.cpp
@@ -111,7 +111,7 @@ String File::read_line() {
 void File::write_text(const String& p_text) {
 	if (!is_open()) THROW_ERROR(Error::IO_ERROR, "can't write on a closed file.");
 	if (!(mode & WRITE) && !(mode & APPEND) && !(mode & EXTRA)) THROW_ERROR(Error::IO_ERROR, "opened file mode isn't supported for writing.");
-	fprintf(_file, p_text.c_str());
+	fprintf(_file, "%s", p_text.c_str());
 }
 
 ptr<Buffer> File::read_bytes() {
@@ -165,6 +165,30 @@ File::~File() {
 void File::_File(ptr<File> p_self, const String& p_path, int p_mode) {
 	p_self->path = p_path;
 	if (p_self->path.size() != 0) p_self->open(p_self->path, p_mode);
+}
+
+// file iterator ------------------------------------------
+
+class _Iterator_File : public Object {
+	REGISTER_CLASS(_Iterator_File, Object) {}
+
+	File* _file = nullptr;
+	String _line;
+public:
+	_Iterator_File() {}
+	_Iterator_File(File* p_file) {
+		_file = p_file;
+		_line = _file->read_line();
+	}
+
+	bool _is_registered() const override { return false; }
+	virtual bool __iter_has_next() override { return _line != ""; }
+	virtual var __iter_next() override { return _line = _file->read_line(); }
+
+};
+
+var File::__iter_begin() {
+	return newptr<_Iterator_File>(this);
 }
 
 }

--- a/tests/analyzer/analyze_files.cpp
+++ b/tests/analyzer/analyze_files.cpp
@@ -3,6 +3,7 @@
 
 
 TEST_CASE("[analyzer_tests]:analyze_files") {
+	ptr<Tokenizer> tokenizer = newptr<Tokenizer>();
 	ptr<Parser> parser = newptr<Parser>();
 	Analyzer analyzer;
 	//String path, source;
@@ -16,7 +17,8 @@ TEST_CASE("[analyzer_tests]:analyze_files") {
 
 	for (int i = 0; i < files.size() - 1; i++) {
 		try {
-			parser->parse(File(files[i], File::READ).read_text(), files[i]);
+			tokenizer->tokenize(newptr<File>(files[i], File::READ));
+			parser->parse(tokenizer);
 			analyzer.analyze(parser);
 		} catch (Throwable& err) {
 			CHECK_MESSAGE(false, err.what());

--- a/tests/analyzer/analyzer_failure.cpp
+++ b/tests/analyzer/analyzer_failure.cpp
@@ -2,6 +2,7 @@
 #include "tests/carbon_tests.h"
 
 TEST_CASE("[analyzer_tests]:analyzer_failure") {
+	ptr<Tokenizer> tokenizer = newptr<Tokenizer>();
 	ptr<Parser> parser = newptr<Parser>();
 	Analyzer analyzer;
 

--- a/tests/analyzer/analyzer_tests.cpp
+++ b/tests/analyzer/analyzer_tests.cpp
@@ -3,6 +3,7 @@
 
 
 TEST_CASE("[analyzer_tests]:analyzer_test") {
+	ptr<Tokenizer> tokenizer = newptr <Tokenizer>();
 	ptr<Parser> parser = newptr<Parser>();
 	Analyzer analyzer;
 
@@ -39,10 +40,10 @@ TEST_CASE("[analyzer_tests]:analyzer_test") {
 	CHECK_NOTHROW__ANALYZE("const C = [1, [2, 3]].pop()[-1];        __assert(C == 3);");
 	CHECK_NOTHROW__ANALYZE("const C = [42].at(0);                   __assert(C == 42);");
 	CHECK_NOTHROW__ANALYZE(R"(
-	const str = "\
+	const S = "\
 line 1
 line 2
-"; __assert(str == "line 1\nline 2\n");
+"; __assert(S == "line 1\nline 2\n");
 	)");
 
 	CHECK_NOTHROW__ANALYZE("const C = 1; func fn(a = C){}");

--- a/tests/analyzer/inheritance_tests.cpp
+++ b/tests/analyzer/inheritance_tests.cpp
@@ -2,6 +2,7 @@
 #include "tests/carbon_tests.h"
 
 TEST_CASE("[analyzer_tests]:inheritance_test+") {
+	ptr<Tokenizer> tokenizer = newptr<Tokenizer>();
 	ptr<Parser> parser = newptr<Parser>();
 	Analyzer analyzer;
 
@@ -26,6 +27,7 @@ TEST_CASE("[analyzer_tests]:inheritance_test+") {
 }
 
 TEST_CASE("[analyzer_tests]:inheritance_test-") {
+	ptr<Tokenizer> tokenizer = newptr<Tokenizer>();
 	ptr<Parser> parser = newptr<Parser>();
 	Analyzer analyzer;
 

--- a/tests/carbon_tests.h
+++ b/tests/carbon_tests.h
@@ -32,7 +32,7 @@ using namespace carbon;
 #include <doctest/doctest.h>
 
 #define NO_PATH "<NO-PATH-SET>"
-#define _PARSE(m_source) parser.parse(m_source, NO_PATH)
+#define _PARSE(m_source) tokenizer->tokenize(m_source, NO_PATH); parser->parse(tokenizer)
 
 #define CHECK_THROWS_ERR(m_type, m_statement)																		        \
 	do {																													\
@@ -50,26 +50,26 @@ using namespace carbon;
 
 #define CHECK_NOTHROW__ANALYZE(m_source)                 \
 do {													 \
-	parser->parse(m_source, NO_PATH);					 \
+	_PARSE(m_source);									 \
 	CHECK_NOTHROW(analyzer.analyze(parser));			 \
 } while (false)
 
 #define CHECK_THROWS__ANALYZE(m_type, m_source)          \
 do {												     \
-	parser->parse(m_source, NO_PATH);				     \
+	_PARSE(m_source);				     				 \
 	CHECK_THROWS_ERR(m_type, analyzer.analyze(parser));  \
 } while(false)
 
 #define CHECK_NOTHROW__CODEGEN(m_source)                   \
 do {													   \
-	parser->parse(m_source, NO_PATH);					   \
+	_PARSE(m_source);					   				   \
 	analyzer->analyze(parser);							   \
 	CHECK_NOTHROW(bytecode = codegen.generate(analyzer));  \
 } while (false)
 
 #define CHECK_NOTHROW__VM(m_source)                        \
 do {										               \
-	parser->parse(m_source, NO_PATH);					   \
+	_PARSE(m_source);									   \
 	analyzer->analyze(parser);				               \
 	bytecode = codegen->generate(analyzer);	               \
 	VM::singleton()->run(bytecode, argv);	               \

--- a/tests/codegen/codegen_tests.cpp
+++ b/tests/codegen/codegen_tests.cpp
@@ -2,6 +2,7 @@
 #include "tests/carbon_tests.h"
 
 TEST_CASE("[codeten_tests]:codegen_tests") {
+	ptr<Tokenizer> tokenizer = newptr<Tokenizer>();
 	ptr<Parser> parser = newptr<Parser>();
 	ptr<Analyzer> analyzer = newptr<Analyzer>();
 	CodeGen codegen;
@@ -15,7 +16,7 @@ TEST_CASE("[codeten_tests]:codegen_tests") {
 	CHECK(bytecode->get_static_var("x") != nullptr); // but value of v is null till runtime.
 	CHECK(bytecode->get_constant("C") == "another string");
 	ptr<CarbonFunction> f = bytecode->get_function("f");
-	CHECK(f != nullptr);
+	REQUIRE(f != nullptr);
 	CHECK(f->get_arg_count() == 2);
 	CHECK(f->get_default_args().size() == 1);
 	CHECK(f->get_default_args()[0] == 2);

--- a/tests/parser/invalid_syntax_tests.cpp
+++ b/tests/parser/invalid_syntax_tests.cpp
@@ -2,7 +2,8 @@
 #include "tests/carbon_tests.h"
 
 TEST_CASE("[parser_tests]:invalid_syntax_test") {
-	Parser parser;
+	ptr<Tokenizer> tokenizer = newptr<Tokenizer>();
+	ptr<Parser> parser = newptr<Parser>();
 
 	// Eof
 	CHECK_THROWS_ERR(Error::UNEXPECTED_EOF, _PARSE("class"));

--- a/tests/parser/valid_syntax_tests.cpp
+++ b/tests/parser/valid_syntax_tests.cpp
@@ -2,7 +2,8 @@
 #include "tests/carbon_tests.h"
 
 TEST_CASE("[parser_tests]:valid_syntax_test") {
-	Parser parser;
+	ptr<Tokenizer> tokenizer = newptr<Tokenizer>();
+	ptr<Parser> parser = newptr<Parser>();
 
 	// variables.
 	CHECK_NOTHROW(_PARSE("var v1; var v2 = 2; var v3 = 3, v4 = 4, v5 = 5;"));
@@ -119,7 +120,7 @@ TEST_CASE("[parser_tests]:valid_syntax_test") {
 
 	// multi line string
 	CHECK_NOTHROW(_PARSE(R"(
-	var str = "\\
+	var s = "\\
 	line 1
 	line 2
 	";

--- a/tests/test_files/z_function.cb
+++ b/tests/test_files/z_function.cb
@@ -1,6 +1,8 @@
 
-func z_function(str) {
-	var n = str.size();
+// TODO: fix: str builtin type -> can't use as local 
+
+func z_function(_str) {
+	var n = _str.size();
 	var z = Array(); z.resize(n);
 	z[0] = 0;
 
@@ -8,14 +10,14 @@ func z_function(str) {
 	for (var i = 1; i < n; i+=1) {
 		if (i >= r) {
 			l = i; r = i;
-			while (r < n && str[r - l] == str[r]) r+= 1;
+			while (r < n && _str[r - l] == _str[r]) r+= 1;
 			z[i] = r - l;
 		} else {
 			if (i + z[i - l] < r) {
 				z[i] = z[i - l];
 			} else {
 				l = i;
-				while (r < n && str[r - l] == str[r]) r+=1;
+				while (r < n && _str[r - l] == _str[r]) r+=1;
 				z[i] = r - l;
 			}
 		}

--- a/tests/test_main.cb
+++ b/tests/test_main.cb
@@ -8,8 +8,13 @@ func f(a, b&) {
 
 func main() {	
 
-	var x = "asdf" + 1;
-	print(x);
+	var in = File("tests/large_file", File.READ);
+	var line = in.read_line();
+	var l = 0;
+	while(line) {
+		println(l+=1, line = in.read_line());
+	}
+	in.close();
 
 	// operator overloading
 	var path = Path("C:/dev") / "path/to" / "file.txt";

--- a/tests/vm/vm_tests.cpp
+++ b/tests/vm/vm_tests.cpp
@@ -2,6 +2,7 @@
 #include "tests/carbon_tests.h"
 
 TEST_CASE("[vm_tests]:vm_tests") {
+	ptr<Tokenizer> tokenizer = newptr<Tokenizer>();
 	ptr<Parser> parser = newptr<Parser>();
 	ptr<Analyzer> analyzer = newptr<Analyzer>();
 	ptr<CodeGen> codegen = newptr<CodeGen>();


### PR DESCRIPTION
`fprintf` was cashed due to unhandled formated string fixed, and file iterator implemented (syntax below)

```gdscript
func main() {
	var file = File("tests/large_file.txt", File.READ);
	for (var line : file) {
		print(line);
	}
}

```

